### PR TITLE
Add new menu item for Specs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ node_modules/
 
 # htmltest
 tmp/
+
+# clones of other repos
+clones/

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,13 @@
+SPEC_DISTRIBUTION_REPO ?= https://github.com/bloodorangeio/distribution-spec.git
+SPEC_DISTRIBUTION_BRANCH ?= reorg-demo
+SPEC_DISTRIBUTION_FILEPATH ?= spec.md
+
+get-specs:
+	mkdir -p clones/
+	rm -rf clones/distribution-spec/
+	git clone --depth=1 --branch $(SPEC_DISTRIBUTION_BRANCH) $(SPEC_DISTRIBUTION_REPO) clones/distribution-spec/
+	cp clones/distribution-spec/$(SPEC_DISTRIBUTION_FILEPATH) content/specs/distribution-spec.md
+
 yarn:
 	yarn
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-SPEC_DISTRIBUTION_REPO ?= https://github.com/bloodorangeio/distribution-spec.git
-SPEC_DISTRIBUTION_BRANCH ?= reorg-demo
+SPEC_DISTRIBUTION_REPO ?= https://github.com/opencontainers/distribution-spec.git
+SPEC_DISTRIBUTION_BRANCH ?= v1.0.0
 SPEC_DISTRIBUTION_FILEPATH ?= spec.md
 
 get-specs:
@@ -17,11 +17,11 @@ serve: yarn
 		--buildFuture \
 		--disableFastRender
 
-production-build:
+production-build: get-specs
 	hugo \
 		--minify
 
-preview-build:
+preview-build: get-specs
 	hugo \
 		--baseURL $(DEPLOY_PRIME_URL) \
 		--buildDrafts \

--- a/config.toml
+++ b/config.toml
@@ -9,6 +9,11 @@ summaryLength = 15
 [markup.highlight]
 style = "paraiso-dark"
 
+[markup]
+  [markup.tableOfContents]
+    endLevel = 5
+    startLevel = 2
+
 [params]
 font_awesome_version = "5.12.0"
 description = "The **Open Container Initiative** is an open governance structure for the express purpose of creating open industry standards around container formats and runtimes."
@@ -89,14 +94,26 @@ url = "/about/security-disclosure"
 weight = 70
 
 [[menu.main]]
-name = "Community"
-identifier ="community"
+name = "Specs"
+identifier = "specs"
 url = "#"
 weight = 20
 
 [[menu.main]]
+name = "Distribution spec"
+parent = "specs"
+url = "/specs/distribution-spec/"
+weight = 10
+
+[[menu.main]]
+name = "Community"
+identifier = "community"
+url = "#"
+weight = 30
+
+[[menu.main]]
 name = "Overview"
-parent ="community"
+parent = "community"
 url = "/community/overview"
 weight = 10
 
@@ -110,19 +127,19 @@ weight = 20
 name = "Join"
 identifier ="join"
 url = "/join"
-weight = 30
+weight = 40
 
 [[menu.main]]
 name = "Blog"
 identifier ="blog"
 url = "/posts/blog"
-weight = 40
+weight = 50
 
 [[menu.main]]
 name = "News"
 identifier ="news"
 url = "#"
-weight = 50
+weight = 60
 
 [[menu.main]]
 name = "Announcements"
@@ -140,7 +157,7 @@ weight = 20
 name = "FAQ"
 identifier ="faq"
 url = "/faq"
-weight = 60
+weight = 70
 
 [[menu.main]]
 name = "Release notices"

--- a/content/specs/.gitignore
+++ b/content/specs/.gitignore
@@ -1,0 +1,1 @@
+!.gitignore


### PR DESCRIPTION
- Added new menu item Specs, including a dropdown for Distribution spec.
- Also added make target to source distribution-spec from its own repo.

Note: This is a draft to display in-progress changes to distribution-spec, should not be merged until v1.0 is released.