### PR TITLE
update copyright year in footer

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -13,7 +13,6 @@ style = "paraiso-dark"
 font_awesome_version = "5.12.0"
 description = "The **Open Container Initiative** is an open governance structure for the express purpose of creating open industry standards around container formats and runtimes."
 herodescription = "Established in June 2015 by Docker and other leaders in the container industry, the OCI currently contains three specifications: the Runtime Specification (runtime-spec),  the Image Specification (image-spec) and the Distribution Specification (distribution-spec). The Runtime Specification outlines how to run a “filesystem bundle” that is unpacked on disk. At a high-level an OCI implementation would download an OCI Image then unpack that image into an OCI Runtime filesystem bundle. At this point the OCI Runtime Bundle would be run by an OCI Runtime."
-copyrightYear = 2020
 favicon = "favicon.png"
 repositoryUrl = "https://github.com/opencontainers/opencontainers.org"
 contentDir = "/content/"

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,5 +1,5 @@
 <footer class="container flex grid self-center grid-cols-12 p-4 md:w-full">
-  <p class="col-span-12 lg:col-span-4">Copyright © {{ site.Params.copyrightYear | markdownify }} The Linux Foundation®. All rights reserved.
+  <p class="col-span-12 lg:col-span-4">Copyright © The Linux Foundation®. All rights reserved.
     The Linux Foundation has registered trademarks and uses trademarks.
     For a list of trademarks of The Linux Foundation, please see our <a href="https://www.linuxfoundation.org/trademark-usage" target="_blank">Trademark Usage</a> page.
     Linux is a registered trademark of Linus Torvalds. <a href="https://www.linuxfoundation.org/trademark-usage" target="_blank">Privacy Policy</a> and <a href="https://www.linuxfoundation.org/terms" target="_blank">Terms of Use</a></p>


### PR DESCRIPTION
Noticed the copyright year in the site footer was a bit out of date, so I've got a quick PR to correct it.