### PR TITLE
fix templates to work properly with latest Hugo version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Hugo-generated assets
 public/
 resources/
+.hugo_build.lock
 
 # npm assets
 node_modules/

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -10,7 +10,7 @@
     <div class="content lg:m-2 xs:col-span-3 lg:col-span-2 {{ if ($isfullwidth) }}lg:col-span-3{{ end }}">
       {{ .Content }}
     </div>
-    {{ if ne ($isfullwidth) }}
+    {{ if not $isfullwidth }}
     <div class="text-sm content xs:col-span-3 lg:col-span-1">
       {{ if ($hastoc) }}
         On this page:

--- a/layouts/partials/page-numbers.html
+++ b/layouts/partials/page-numbers.html
@@ -8,7 +8,7 @@
 
     <ul class="lekton">
       <!-- First page. -->
-      {{ if ne $paginator.PageNumber 1 }}
+      {{ if not ( eq $paginator.PageNumber 1 ) }}
       <li class="inline-block">
         <a  href="{{ $paginator.First.URL }}" class="p-2 hover:text-mediumpurple">
           ««
@@ -71,7 +71,7 @@
       </li>
       {{ end }}
       <!-- Last page. -->
-      {{ if ne $paginator.PageNumber $paginator.TotalPages }}
+      {{ if not ( eq $paginator.PageNumber $paginator.TotalPages ) }}
       <li class="inline-block">
         <a href="{{ $paginator.Last.URL }}" class="p-2 hover:text-mediumpurple">
           »»

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@ publish = "public"
 command = "make production-build"
 
 [build.environment]
-HUGO_VERSION = "0.71.0"
+HUGO_VERSION = "0.115.1"
 
 [context.deploy-preview]
 command = "make preview-build"


### PR DESCRIPTION
without this change, running with hugo version `v0.115.1+extended`, upon running `make serve` we get the following error:

```
Error: error building site: render: failed to render pages: render of "page" failed: "....../opencontainers.org/layouts/_default/single.html:13:10": execute of template failed: template: _default/single.html:13:10: executing "main" at <ne ($isfullwidth)>: error calling ne: missing arguments for comparison
```