### PR TITLE
Add OCI in 2024 blog post

### DIFF
--- a/content/posts/blog/2024-01-22-oci-in-2024.md
+++ b/content/posts/blog/2024-01-22-oci-in-2024.md
@@ -31,7 +31,11 @@ These TOB members join the following existing members, who are each in the middl
 * Derek McGowan [Docker]
 * Aleksa Sarai [SUSE]
 
-For outgoing TOB members, we would like to [thank](https://github.com/opencontainers/tob/blob/main/EMERITUS.md) TODOfor their contributions to container standardization!
+For outgoing TOB members, we would like to [thank](https://github.com/opencontainers/tob/blob/main/EMERITUS.md) them for their contributions to container standardization!
+
+* Josh Dolitsky [Chainguard] (term date: 1/29/2022 - 1/29/2024)
+* Jon Johnson [Chainguard] (term date: 1/29/2022 - 1/29/2024)
+* Nisha Kumar [Oracle] (term date: 1/29/2022 - 1/29/2024)
 
 In 2024, we plan on focusing efforts on improved conformance tooling, security and shipping new versions of the OCI specifications. Join us in Seattle at [Container Plumbing Day](https://events.linuxfoundation.org/container-plumbing-days/)!
 

--- a/content/posts/blog/2024-01-22-oci-in-2024.md
+++ b/content/posts/blog/2024-01-22-oci-in-2024.md
@@ -1,0 +1,35 @@
+---
+title: OCI in 2024 and TOB Election Results
+author:
+  name: Open Container Initiative
+  tag: oci
+tags: blog
+date: 2024-01-22
+---
+
+The OCI wrapped up a great 2023 and shipped some new releases and initatives:
+
+* Shipped OCI Runtime Spec 1.1: https://opencontainers.org/release-notices/v1-1-0-runtime-spec/ 
+* Established Image Compatibility Working Group: https://github.com/opencontainers/tob/pull/128
+* Established FreeBSD Working Group: https://github.com/opencontainers/tob/pull/133
+
+We also started off the new year by shipping runc v1.11:
+https://github.com/opencontainers/runc/releases/tag/v1.1.11
+
+To further kick off 2024, we are excited to announce the following four board members are joining or returning to the [OCI Technical Oversight Board (TOB)](https://opencontainers.org/about/tob). The TOB comprises independently elected individuals who provide oversight of the technical leadership and serve as a point of appeal. Each member has been elected to serve a two-year term:
+
+* TODO
+
+These TOB members join the following existing members, who are each in the middle of two-year terms:
+
+* Josh Dolitsky [Chainguard]
+* Phil Estes [Amazon]
+* Jon Johnson [Google]
+* Samuel Karp [Google]
+* Nisha Kumar [Oracle]
+
+For outgoing TOB members, we would like to [thank](https://github.com/opencontainers/tob/blob/main/EMERITUS.md) TODOfor their contributions to container standardization!
+
+In 2024, we plan on focusing efforts on improved conformance tooling, security and shipping new versions of the OCI specifications. Join us in Seattle at [Container Plumbing Day](https://events.linuxfoundation.org/container-plumbing-days/)!
+
+If you’re interested in contributing to OCI, please join the [OCI developer community](https://opencontainers.org/community). If you’re interested in building products on OCI technology, [join as a member](https://opencontainers.org/join) and visit [https://github.com/opencontainers](https://github.com/opencontainers) for more details about releases and specifications in development.

--- a/content/posts/blog/2024-01-22-oci-in-2024.md
+++ b/content/posts/blog/2024-01-22-oci-in-2024.md
@@ -18,7 +18,11 @@ https://github.com/opencontainers/runc/releases/tag/v1.1.11
 
 To further kick off 2024, we are excited to announce the following four board members are joining or returning to the [OCI Technical Oversight Board (TOB)](https://opencontainers.org/about/tob). The TOB comprises independently elected individuals who provide oversight of the technical leadership and serve as a point of appeal. Each member has been elected to serve a two-year term:
 
-* TODO
+* Giuseppe Scrivano [Red Hat]
+* Ramkumar Chinchani [Cisco]
+* Phil Estes [AWS]
+* Samuel Karp [Google]
+* Sajay Antony [Microsoft]
 
 These TOB members join the following existing members, who are each in the middle of two-year terms:
 

--- a/content/posts/blog/2024-01-22-oci-in-2024.md
+++ b/content/posts/blog/2024-01-22-oci-in-2024.md
@@ -22,11 +22,10 @@ To further kick off 2024, we are excited to announce the following four board me
 
 These TOB members join the following existing members, who are each in the middle of two-year terms:
 
-* Josh Dolitsky [Chainguard]
-* Phil Estes [Amazon]
-* Jon Johnson [Google]
-* Samuel Karp [Google]
-* Nisha Kumar [Oracle]
+* Brandon Mitchell [Independent]
+* Vincent Batts [Microsoft]
+* Derek McGowan [Docker]
+* Aleksa Sarai [SUSE]
 
 For outgoing TOB members, we would like to [thank](https://github.com/opencontainers/tob/blob/main/EMERITUS.md) TODOfor their contributions to container standardization!
 

--- a/content/posts/blog/2024-01-22-oci-in-2024.md
+++ b/content/posts/blog/2024-01-22-oci-in-2024.md
@@ -16,7 +16,7 @@ The OCI wrapped up a great 2023 and shipped some new releases and initatives:
 We also started off the new year by shipping runc v1.11:
 https://github.com/opencontainers/runc/releases/tag/v1.1.11
 
-To further kick off 2024, we are excited to announce the following four board members are joining or returning to the [OCI Technical Oversight Board (TOB)](https://opencontainers.org/about/tob). The TOB comprises independently elected individuals who provide oversight of the technical leadership and serve as a point of appeal. Each member has been elected to serve a two-year term:
+To further kick off 2024, we are excited to announce the following five board members are joining or returning to the [OCI Technical Oversight Board (TOB)](https://opencontainers.org/about/tob). The TOB comprises independently elected individuals who provide oversight of the technical leadership and serve as a point of appeal. Each member has been elected to serve a two-year term:
 
 * Giuseppe Scrivano [Red Hat]
 * Ramkumar Chinchani [Cisco]


### PR DESCRIPTION
Kick off a draft of OCI in 2024 blog post with pending TOB results.