### PR TITLE
content/community/overview: Drop stale Zoom link

### DIFF
--- a/content/community/overview.md
+++ b/content/community/overview.md
@@ -11,7 +11,7 @@ The technical community working on developing standards around container formats
 
 ## Open meetings
 
-The technical community hosts a weekly open meeting, currently held on Thursdays at 10:00 AM (US Pacific). Everyone is welcome to participate via [Zoom](https://zoom.my.us/opencontainers).  Our agenda is maintained on our [HackMD page](https://hackmd.io/El8Dd2xrTlCaCG59ns5cwg), and everyone is welcome to propose additional topics or suggest other agenda alterations there. Minutes are embedded in the HackMD document and recordings are made available on our [YouTube channel](https://www.youtube.com/channel/UCpGceic1q4-3Tai0kgeBcwg) for those who are unable to join the call.
+The technical community hosts a weekly open meeting, currently held on Thursdays at 10:00 AM (US Pacific). Everyone is welcome to participate. The Zoom link and our agenda are maintained on our [HackMD page](https://hackmd.io/El8Dd2xrTlCaCG59ns5cwg), and everyone is welcome to propose additional topics or suggest other agenda alterations there. Minutes are embedded in the HackMD document and recordings are made available on our [YouTube channel](https://www.youtube.com/channel/UCpGceic1q4-3Tai0kgeBcwg) for those who are unable to join the call.
 
 ## Mailing list 
 


### PR DESCRIPTION
The outgoing link dates back at least as far as 24e9dc1ca0 (Migrate community page, 2020-05-14, #34), although it's not clear from that commit message where the content had migrated from.  I'm not sure the link I'm removing ever worked, but it's not resolving now:

```console
$ curl https://zoom.my.us/opencontainers
curl: (6) Could not resolve host: zoom.my.us
```

[The referenced HackMD page](https://hackmd.io/El8Dd2xrTlCaCG59ns5cwg) currently includes:

> Conference URL with embedded passcode

linking `https://zoom.us/j/6449415895?pwd=...`, and having that one place to keep up to date seems more sustainable than trying to track that link in both HackMD and here in Git.