### PR TITLE
Release image-spec v1.1.1

### DIFF
--- a/content/release-notices/overview.md
+++ b/content/release-notices/overview.md
@@ -10,6 +10,7 @@ Per the [OCI Charter’s IP Policy](https://github.com/opencontainers/tob/blob/m
 - [v1.0.1 image-spec (11/7/17)](/release-notices/v1-0-1-image-spec)
 - [v1.0.2 image-spec (11/17/21)](/release-notices/v1-0-2-image-spec)
 - [v1.1.0 image-spec (02/05/24)](/release-notices/v1-1-0-image-spec)
+- [v1.1.1 image-spec (4/2/25)](/release-notices/v1-1-1-image-spec)
 - [v1.0.1 runtime-spec (11/7/17)](/release-notices/v1-0-1-runtime-spec)
 - [v1.0.2 runtime-spec (3/27/20)](/release-notices/v1-0-2-runtime-spec)
 - [v1.1.0 runtime-spec (7/21/23)](/release-notices/v1-1-0-runtime-spec)

--- a/content/release-notices/v1-1-1-image-spec.md
+++ b/content/release-notices/v1-1-1-image-spec.md
@@ -1,0 +1,34 @@
+---
+title: "OCI image-spec v. 1.1.1 release notice"
+---
+
+**Date: 4/2/2025**
+
+**We are excited to inform you that OCI image-spec has released version 1.1.1!**
+
+The [OCI Charter’s IP Policy](https://www.opencontainers.org/about/governance), in Section 8.d., provides for notice of the release of a new version of the OCI specification to be provided to all Members. This notice is a reminder that each release triggers the obligations set forth in the Open Web Foundation Final Specification Agreement (OWFa 1.0) (Patent Only) for all Members on the date 30 days after the date of this notice. Links for your convenience:
+
+- GitHub links for release version 1.1.1: <https://github.com/opencontainers/image-spec/releases/tag/v1.1.1>
+- The OCI Charter and IP Policy: <https://www.opencontainers.org/about/governance>
+- The OWFa 1.0 (Patent Only) license: <https://www.openwebfoundation.org/the-agreements/the-owf-1-0-agreements-granted-claims/owfa-1-0-patent-only>
+
+## 30 Day IPR Period
+
+The 30 day period has passed and all OCI members listed below are bound by the obligations set forth in the Open Web Foundation Final Specification Agreement (OWFa 1.0) (Patent Only):
+
+- Alibaba
+- Amazon Web Services
+- Chainguard
+- Cisco Systems
+- Docker
+- Easystack
+- Goldman Sachs
+- Google
+- Huawei
+- IBM
+- Microsoft
+- OpenStack
+- Red Hat
+- Replicated
+- Sysdig
+- Weaveworks


### PR DESCRIPTION
Set as draft during the 30 day IPR window from March 3 to April 2. Reviews welcome since this will hopefully post on the 2nd.