### PR TITLE
Update community page with calendar link

### DIFF
--- a/content/community/overview.md
+++ b/content/community/overview.md
@@ -11,39 +11,47 @@ The technical community working on developing standards around container formats
 
 ## Open meetings
 
-The technical community hosts a weekly open meeting, currently held on Thursdays at 10:00 AM (US Pacific). Everyone is welcome to participate. The Zoom link and our agenda are maintained on our [HackMD page](https://hackmd.io/El8Dd2xrTlCaCG59ns5cwg), and everyone is welcome to propose additional topics or suggest other agenda alterations there. Minutes are embedded in the HackMD document and recordings are made available on our [YouTube channel](https://www.youtube.com/channel/UCpGceic1q4-3Tai0kgeBcwg) for those who are unable to join the call.
+The technical community hosts a weekly open meeting, currently held on Thursdays at 10:00 AM (US Pacific).
+See the [Google Calendar](https://calendar.google.com/calendar/embed?src=linuxfoundation.org_i0sado0i37eknar51vsu8md5hg%40group.calendar.google.com) for the current meeting schedule.
+Everyone is welcome to participate.
+The Zoom link and our agenda are maintained on our [HackMD page](https://hackmd.io/El8Dd2xrTlCaCG59ns5cwg), and everyone is welcome to propose additional topics or suggest other agenda alterations there.
+Minutes are embedded in the HackMD document and recordings are made available on our [YouTube channel](https://www.youtube.com/channel/UCpGceic1q4-3Tai0kgeBcwg) for those who are unable to join the call.
 
-## Mailing list 
+## Mailing list
 
 - [Google Group (developer community)](https://groups.google.com/a/opencontainers.org/forum/#!forum/dev)
 
-## Chat 
+## Chat
 
-Given the existence of both pre-Slack communication via IRC and the adoption of Slack by many communities, we have a bridge between the
-IRC channel #opencontainers on freenode.net and the #general channel on [OCI Slack](https://communityinviter.com/apps/opencontainers/join-the-oci-community). For Matrix users, this channel
-is also bridged to #opencontainers:matrix.org.
+OCI uses Slack for discussions.
+Use the [community inviter](https://communityinviter.com/apps/opencontainers/join-the-oci-community) to join.
 
-## GitHub 
+## GitHub
+
+A majority of the work in OCI is performed in GitHub.
+This includes the specifications:
+
+- [runtime-spec](https://github.com/opencontainers/runtime-spec)
+- [image-spec](https://github.com/opencontainers/image-spec)
+- [distribution-spec](https://github.com/opencontainers/distribution-spec)
+
+There are also various tools and libraries, including:
 
 - [runc](https://github.com/opencontainers/runc)
-- [runtime-spec](https://github.com/opencontainers/runtime-spec) / [image-spec](https://github.com/opencontainers/image-spec)
-- [runtime-tools](https://github.com/opencontainers/runtime-tools) / [image-tools](https://github.com/opencontainers/image-tools)
-- [go-digest](https://github.com/opencontainers/go-digest) / [selinux](https://github.com/opencontainers/selinux)
-- [distribution-spec](https://github.com/opencontainers/distribution-spec)
-- [artifacts](https://github.com/opencontainers/artifacts)
-- [umoci](https://github.com/opencontainers/umoci)
-- [oci-conformance](https://github.com/opencontainers/oci-conformance)
+- [go-digest](https://github.com/opencontainers/go-digest)
 
-## Technical oversight board (TOB) 
+For a full list of repositories, see the [OCI organization in GitHub](https://github.com/opencontainers).
+
+## Technical oversight board (TOB)
 
 - [TOB on GitHub](https://github.com/opencontainers/tob)
 - [TOB on Google Groups](https://groups.google.com/a/opencontainers.org/forum/#!forum/tob)
 
-## Trademark board 
+## Trademark board
 
 - [Google Groups](https://groups.google.com/a/opencontainers.org/forum/#!forum/trademark-board) (Members only)
 
-## Certification working group 
+## Certification working group
 
 - [Google Group](https://groups.google.com/a/opencontainers.org/forum/#!forum/cert-wg) (Members only)
 - [OCI Certified Program](/community/certified)


### PR DESCRIPTION
This also cleans some markdown linting errors and removes some references to archived content.